### PR TITLE
Feat/fsd class8

### DIFF
--- a/auto_neutron/fsd.py
+++ b/auto_neutron/fsd.py
@@ -31,6 +31,7 @@ class FrameShiftDrive:
         5: 2.45,
         6: 2.6,
         7: 2.75,
+        8: 2.9,
     }
     _CLASS_CONSTANTS: t.ClassVar[dict[int, int]] = {1: 11, 2: 10, 3: 8, 4: 10, 5: 12}
 
@@ -165,4 +166,10 @@ _BASE_FSDS = {  # base unengineered FSDs
     "int_hyperdrive_overcharge_size7_class3": SCOFrameShiftDrive(7, 3, 12.80, 2700),
     "int_hyperdrive_overcharge_size7_class4": SCOFrameShiftDrive(7, 4, 12.80, 2700),
     "int_hyperdrive_overcharge_size7_class5": SCOFrameShiftDrive(7, 5, 13.10, 3000),
+    "int_hyperdrive_overcharge_size8_class1": SCOFrameShiftDrive(8, 1, 13.60, 2800),
+    "int_hyperdrive_overcharge_size8_class2": SCOFrameShiftDrive(8, 2, 20.40, 4200),
+    "int_hyperdrive_overcharge_size8_class3": SCOFrameShiftDrive(8, 3, 20.40, 4200),
+    "int_hyperdrive_overcharge_size8_class4": SCOFrameShiftDrive(8, 4, 20.40, 4200),
+    "int_hyperdrive_overcharge_size8_class5": SCOFrameShiftDrive(8, 5, 20.70, 4670),
+    "int_hyperdrive_overcharge_size8_class5_overchargebooster_mkii": SCOFrameShiftDrive(8, 5, 6.80, 4670),
 }

--- a/auto_neutron/fsd.py
+++ b/auto_neutron/fsd.py
@@ -105,6 +105,13 @@ class SCOFrameShiftDrive(FrameShiftDrive):
     _CLASS_CONSTANTS = {1: 8, 2: 12, 3: 12, 4: 12, 5: 13}
 
 
+@dataclasses.dataclass(slots=True, frozen=True)
+class SCOFrameShiftDriveMkII(FrameShiftDrive):
+    """Supercruise overcharge FSD."""
+
+    _CLASS_CONSTANTS = {5: 4}
+
+
 _BASE_FSDS = {  # base unengineered FSDs
     "int_hyperdrive_size2_class1": FrameShiftDrive(2, 1, 0.60, 48),
     "int_hyperdrive_size2_class2": FrameShiftDrive(2, 2, 0.60, 54),
@@ -171,5 +178,7 @@ _BASE_FSDS = {  # base unengineered FSDs
     "int_hyperdrive_overcharge_size8_class3": SCOFrameShiftDrive(8, 3, 20.40, 4200),
     "int_hyperdrive_overcharge_size8_class4": SCOFrameShiftDrive(8, 4, 20.40, 4200),
     "int_hyperdrive_overcharge_size8_class5": SCOFrameShiftDrive(8, 5, 20.70, 4670),
-    "int_hyperdrive_overcharge_size8_class5_overchargebooster_mkii": SCOFrameShiftDrive(8, 5, 6.80, 4670),
+    "int_hyperdrive_overcharge_size8_class5_overchargebooster_mkii": SCOFrameShiftDriveMkII(
+        8, 5, 6.80, 4670
+    ),
 }


### PR DESCRIPTION
This solves issue #61 .

Caveats: Neutron boosted jump ranges for 8A MKII drives are calculated too low. This will need further adjustment when Spansh have expanded their API to allow us to specify a neutron boost multiplier.